### PR TITLE
Handle updating unstable packages

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -81,7 +81,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: yaxitech/nix-install-pkgs-action@v3
+    - uses: yaxitech/nix-install-pkgs-action@v5
       with:
         packages: "nix-update,jq"
         inputs-from: nixpkgs

--- a/action.yaml
+++ b/action.yaml
@@ -131,7 +131,7 @@ runs:
         PATH_TO_FLAKE_DIR: ${{ inputs.path-to-flake-dir }}
     - name: Create PR
       id: create-pr
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ inputs.token }}
         branch: ${{ inputs.branch }}

--- a/nix-update.sh
+++ b/nix-update.sh
@@ -28,7 +28,14 @@ updatePackages() {
         continue
     fi
     echo "Updating package '$PACKAGE'."
-    nix-update --flake --commit "$PACKAGE" 1>/dev/null
+    # if current version is unstable, update to latest commit of default branch
+    CURRENT_VERSION=$(nix derivation show .#"$PACKAGE" | jq -r '.[].env.version')
+    if [[ $CURRENT_VERSION == *"unstable"* ]]; then
+      VERSION_FLAG="branch"
+    else
+      VERSION_FLAG="stable"
+    fi
+    nix-update --flake --commit --version="$VERSION_FLAG" "$PACKAGE" 1>/dev/null
   done
 }
 


### PR DESCRIPTION
I have a few packages that track latest commit of a branch rather than a version -- typically I handle that with the `--version=branch` argument to `nix-update`. To handle those as part of the action, I added a check against a package `version` parameter -- if it contains the word `unstable` (which is what `nix-update`  and the [nixpkgs versioning convention](https://github.com/NixOS/nixpkgs/blob/315c43d480a69a276c491e5118c35ab4a45a5ba5/pkgs/README.md?plain=1#L387) use to denote packages like this), then it does `--version=branch`; otherwise, it does `--version=stable` (which should be the default mode).

I also bumped `create-pull-request` as I ran into [this issue](https://github.com/peter-evans/create-pull-request/issues/2790) running the action if an PR from a previous run was still open.