### PR TITLE
fix: failed to open archive by bumping nix-install-pkgs-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install Nix
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v31.5.2
       - name: Update flake packages
         uses: selfuryon/nix-update-action@v1
 ```
@@ -45,9 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install Nix
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v31.5.2
       - name: Update flake packages
         uses: selfuryon/nix-update-action@v1
         with:
@@ -69,9 +69,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install Nix
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v31.5.2
       - name: Update flake packages
         uses: selfuryon/nix-update-action@v1
         with:
@@ -93,9 +93,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install Nix
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v31.5.2
       - name: Update flake packages
         id: update
         uses: selfuryon/nix-update-action@v1
@@ -118,9 +118,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install Nix
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v31.5.2
       - name: Update flake packages
         id: update
         uses: selfuryon/nix-update-action@v1
@@ -156,9 +156,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install Nix
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v31.5.2
       - name: Update flake packages
         id: update
         uses: selfuryon/nix-update-action@v1
@@ -184,9 +184,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install Nix
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v31.5.2
       - name: Update flake packages
         id: update
         uses: selfuryon/nix-update-action@v1

--- a/action.yaml
+++ b/action.yaml
@@ -88,7 +88,7 @@ runs:
     - name: Import bot's GPG key for signing commits
       if: ${{ inputs.sign-commits == 'true' }}
       id: import-gpg
-      uses: crazy-max/ghaction-import-gpg@v5
+      uses: crazy-max/ghaction-import-gpg@v6.3.0
       with:
         gpg_private_key: ${{ inputs.gpg-private-key }}
         fingerprint: ${{ inputs.gpg-fingerprint }}
@@ -131,7 +131,7 @@ runs:
         PATH_TO_FLAKE_DIR: ${{ inputs.path-to-flake-dir }}
     - name: Create PR
       id: create-pr
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@v7.0.8
       with:
         token: ${{ inputs.token }}
         branch: ${{ inputs.branch }}

--- a/action.yaml
+++ b/action.yaml
@@ -81,7 +81,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: yaxitech/nix-install-pkgs-action@v3
+    - uses: yaxitech/nix-install-pkgs-action@v6
       with:
         packages: "nix-update,jq"
         inputs-from: nixpkgs


### PR DESCRIPTION
This fixes the following error, which I got with `nix-install-pkgs-action` 3 and 5: https://github.com/gepbird/nur-packages/actions/runs/17166534577/job/48708074268. With version 6 the action works: https://github.com/gepbird/nur-packages/actions/runs/17166548452/job/48708116573

While we're at it, let's update all the actions. I glanced at all the breaking changes, they shouldn't cause issues in this action. Tested those changes in https://github.com/gepbird/nur-packages/actions/runs/17174584306/job/48728749825

Please also create a new release for this, if necessary bump it in README.md