### PR TITLE
feat: run nix-update with --use-update-script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: cachix/install-nix-action@v20
+        with:
+          nix_path: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-unstable.tar.gz"
       - name: Update flake packages
         uses: selfuryon/nix-update-action@v1
 ```
@@ -48,6 +50,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: cachix/install-nix-action@v20
+        with:
+          nix_path: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-unstable.tar.gz"
       - name: Update flake packages
         uses: selfuryon/nix-update-action@v1
         with:
@@ -72,6 +76,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: cachix/install-nix-action@v20
+        with:
+          nix_path: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-unstable.tar.gz"
       - name: Update flake packages
         uses: selfuryon/nix-update-action@v1
         with:
@@ -96,6 +102,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: cachix/install-nix-action@v20
+        with:
+          nix_path: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-unstable.tar.gz"
       - name: Update flake packages
         id: update
         uses: selfuryon/nix-update-action@v1
@@ -121,6 +129,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: cachix/install-nix-action@v20
+        with:
+          nix_path: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-unstable.tar.gz"
       - name: Update flake packages
         id: update
         uses: selfuryon/nix-update-action@v1
@@ -159,6 +169,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: cachix/install-nix-action@v20
+        with:
+          nix_path: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-unstable.tar.gz"
       - name: Update flake packages
         id: update
         uses: selfuryon/nix-update-action@v1
@@ -187,6 +199,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: cachix/install-nix-action@v20
+        with:
+          nix_path: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-unstable.tar.gz"
       - name: Update flake packages
         id: update
         uses: selfuryon/nix-update-action@v1

--- a/nix-update.sh
+++ b/nix-update.sh
@@ -28,7 +28,7 @@ updatePackages() {
         continue
     fi
     echo "Updating package '$PACKAGE'."
-    nix-update --flake --commit "$PACKAGE" 1>/dev/null
+    nix-update --flake --commit --use-update-script "$PACKAGE" 1>/dev/null
   done
 }
 


### PR DESCRIPTION
This allows running custom update scripts the nixpkgs style: when a package has `passthru.updateScript` which can be `nix-update-script` with extra arguments, `gitUpdater` or a custom shell script, `nix-update` will invoke that just like in `nixpkgs`.

In the background `nix-update --use-update-script` calls the nixpkgs maintainer update script (https://github.com/Mic92/nix-update/blob/d44f8b524ccea0243009eb07ef4b995734cddbb4/nix_update/update.py#L440-L448), it can be integrated into repositories like someone's nur-packages, but it's not trivial to do, and another solution would be nicer.

"Depends" on https://github.com/selfuryon/nix-update-action/pull/6